### PR TITLE
Update node to 18.18.0

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -30,8 +30,8 @@ download_node() {
     #   fail_bin_install node $node_version;
     # fi
 
-    echo "Downloading and installing node 16.5.0..."
-    local url="https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v16.5.0-linux-x64.tar.gz"
+    echo "Downloading and installing node 18.20.5..."
+    local url="https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.20.5-linux-x64.tar.gz"
     local code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o ${cached_node} --write-out "%{http_code}")
     if [ "$code" != "200" ]; then
       echo "Unable to download node: $code" && false


### PR DESCRIPTION
https://status.heroku.com/incidents/2727

```
❯ wget https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.18.0-linux-x64.tar.gz
--2024-11-21 08:10:19--  https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v18.18.0-linux-x64.tar.gz
Resolving heroku-nodebin.s3.us-east-1.amazonaws.com (heroku-nodebin.s3.us-east-1.amazonaws.com)... 3.5.1.66, 54.231.167.42, 52.217.135.34, ...
Connecting to heroku-nodebin.s3.us-east-1.amazonaws.com (heroku-nodebin.s3.us-east-1.amazonaws.com)|3.5.1.66|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 44566491 (43M) [application/x-tar]
Saving to: ‘node-v18.18.0-linux-x64.tar.gz’

node-v18.18.0-linux-x64.tar.gz                                       29%[================================================>                                                                                                                   ]  12.73M  3.52MB/s    eta 9s     ^C
```